### PR TITLE
Feature/186 onboard rest

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -32,8 +32,13 @@ jobs:
       - name: 'Build launcher'
         run: ./gradlew :launcher:shadowJar
 
+      - name: 'Upgrade docker-compose (for --wait option)'
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
       - name: 'Run application in docker-compose'
-        run: docker-compose up --build --detach
+        run: docker-compose up --build --wait
         timeout-minutes: 10
 
       - name: 'Unit and system tests'

--- a/extensions/registration-service/build.gradle.kts
+++ b/extensions/registration-service/build.gradle.kts
@@ -8,6 +8,8 @@ val edcVersion: String by project
 val edcGroup: String by project
 val jupiterVersion: String by project
 val assertj: String by project
+val mockitoVersion: String by project
+val faker: String by project
 
 dependencies {
     implementation("${edcGroup}:core:${edcVersion}")
@@ -15,5 +17,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
+    testImplementation("org.mockito:mockito-core:${mockitoVersion}")
+    testImplementation("com.github.javafaker:javafaker:${faker}")
 }
 

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/InMemoryParticipantStore.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/InMemoryParticipantStore.java
@@ -1,0 +1,24 @@
+package org.eclipse.dataspaceconnector.registration.api;
+
+import org.eclipse.dataspaceconnector.registration.api.model.Participant;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory store for dataspace participants.
+ */
+public class InMemoryParticipantStore {
+
+    private final Map<String, Participant> participantStore = new LinkedHashMap<>();
+
+    public List<Participant> listParticipants() {
+        return new ArrayList<>(participantStore.values());
+    }
+
+    public void addParticipant(Participant participant) {
+        participantStore.put(participant.getName(), participant);
+    }
+}

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -1,8 +1,6 @@
 package org.eclipse.dataspaceconnector.registration.api;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
@@ -11,10 +9,6 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.eclipse.dataspaceconnector.registration.api.model.Participant;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import org.eclipse.dataspaceconnector.registration.api.model.Participant;
-import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 
 import java.util.List;
 
@@ -38,15 +32,10 @@ public class RegistrationApiController {
         this.service = service;
     }
 
-    /**
-     * Lists all dataspace participants.
-     *
-     * @return list of dataspace participants.
-     */
     @Path("/participants")
     @GET
-    @Operation(description = "Gets all dataspace participants.",
-            responses = {@ApiResponse(description = "Dataspace participants.")})
+    @Operation(description = "Gets all dataspace participants.")
+    @ApiResponse(description = "Dataspace participants.")
     public List<Participant> listParticipants() {
         return service.listParticipants();
     }

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -7,6 +7,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import org.eclipse.dataspaceconnector.registration.api.model.Participant;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.eclipse.dataspaceconnector.registration.api.model.Participant;
@@ -24,25 +28,34 @@ import java.util.List;
 public class RegistrationApiController {
 
     private final RegistrationService service;
-    private final Monitor monitor;
 
     /**
      * Constructs an instance of {@link RegistrationApiController}
      *
      * @param service service handling the registration service logic.
-     * @param monitor logging monitor.
      */
-    public RegistrationApiController(RegistrationService service, Monitor monitor) {
+    public RegistrationApiController(RegistrationService service) {
         this.service = service;
-        this.monitor = monitor;
     }
 
+    /**
+     * Lists all dataspace participants.
+     *
+     * @return list of dataspace participants.
+     */
     @Path("/participants")
     @GET
     @Operation(description = "Gets all dataspace participants.",
             responses = {@ApiResponse(description = "Dataspace participants.")})
     public List<Participant> listParticipants() {
-        monitor.info("List all participants of the dataspace.");
         return service.listParticipants();
+    }
+
+    @Path("/participant")
+    @Operation(description = "Asynchronously request to add a dataspace participant.")
+    @ApiResponse(responseCode = "204", description = "No content")
+    @POST
+    public void addParticipant(Participant participant) {
+        service.addParticipant(participant);
     }
 }

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
@@ -30,7 +30,7 @@ public class RegistrationService {
     }
 
     public void addParticipant(Participant participant) {
-        monitor.info("Adding a participants in the dataspace.");
+        monitor.info("Adding a participant in the dataspace.");
         participantStore.addParticipant(participant);
     }
 }

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
@@ -1,42 +1,22 @@
 package org.eclipse.dataspaceconnector.registration.api;
 
 import org.eclipse.dataspaceconnector.registration.api.model.Participant;
-import org.eclipse.dataspaceconnector.spi.EdcException;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiPredicate;
-import java.util.stream.Collectors;
 
 /**
- * Implementation of registration service interface that fetches participants list from json files.
+ * Registration service for dataspace participants.
  */
 public class RegistrationService {
 
-    private final Path nodeJsonDir;
-    private final String nodeJsonPrefix;
-    private final TypeManager typeManager;
     private final Monitor monitor;
+    private final InMemoryParticipantStore participantStore;
 
-    /**
-     * Constructs an instance of {@link RegistrationService}
-     *
-     * @param nodeJsonDir    directory containing source JSON files
-     * @param nodeJsonPrefix prefix to filter source JSON files on
-     * @param typeManager    type manager service
-     * @param monitor        monitor service
-     */
-    public RegistrationService(Path nodeJsonDir, String nodeJsonPrefix, TypeManager typeManager, Monitor monitor) {
-        this.nodeJsonDir = nodeJsonDir;
-        this.nodeJsonPrefix = nodeJsonPrefix;
-        this.typeManager = typeManager;
+    public RegistrationService(Monitor monitor, InMemoryParticipantStore participantStore) {
         this.monitor = monitor;
+        this.participantStore = participantStore;
     }
 
     /**
@@ -45,27 +25,12 @@ public class RegistrationService {
      * @return list of dataspace participants.
      */
     public List<Participant> listParticipants() {
-        try (var files = Files.find(nodeJsonDir, 1, startsWithPrefix())) {
-            return files
-                    .map(this::mapToParticipant)
-                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            monitor.severe("Listing all participants failed.", e);
-            throw new EdcException(e);
-        }
+        monitor.info("List all participants of the dataspace.");
+        return new ArrayList<>(participantStore.listParticipants());
     }
 
-    @NotNull
-    private BiPredicate<Path, BasicFileAttributes> startsWithPrefix() {
-        return (path, attrs) -> path.toFile().getName().startsWith(nodeJsonPrefix);
-    }
-
-    private Participant mapToParticipant(Path path) {
-        try {
-            return typeManager.readValue(Files.readString(path), Participant.class);
-        } catch (IOException e) {
-            monitor.severe(String.format("Error while reading participant from path %s", path), e);
-            throw new EdcException(e);
-        }
+    public void addParticipant(Participant participant) {
+        monitor.info("Adding a participants in the dataspace.");
+        participantStore.addParticipant(participant);
     }
 }

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationServiceApiExtension.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationServiceApiExtension.java
@@ -5,11 +5,6 @@ import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 
-import java.nio.file.Path;
-import java.util.Objects;
-
-import static org.eclipse.dataspaceconnector.common.configuration.ConfigurationFunctions.propOrEnv;
-
 /**
  * EDC extension to boot the services used by the Registration Service.
  */

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationServiceApiExtension.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationServiceApiExtension.java
@@ -20,12 +20,9 @@ public class RegistrationServiceApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var nodeJsonPath = Path.of(Objects.requireNonNull(propOrEnv("NODES_JSON_DIR", "registry"), "Env var NODES_JSON_DIR is null"));
-        var nodeJsonPrefix = Objects.requireNonNull(propOrEnv("NODES_JSON_FILES_PREFIX", "registry-"), "Env var NODES_JSON_FILES_PREFIX is null");
-
-        var typeManager = context.getTypeManager();
         var monitor = context.getMonitor();
-        var registrationService = new RegistrationService(nodeJsonPath, nodeJsonPrefix, typeManager, monitor);
-        webService.registerResource(new RegistrationApiController(registrationService, monitor));
+        var participantStore = new InMemoryParticipantStore();
+        var registrationService = new RegistrationService(monitor, participantStore);
+        webService.registerResource(new RegistrationApiController(registrationService));
     }
 }

--- a/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/api/InMemoryParticipantStoreTest.java
+++ b/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/api/InMemoryParticipantStoreTest.java
@@ -1,0 +1,37 @@
+package org.eclipse.dataspaceconnector.registration.api;
+
+import org.eclipse.dataspaceconnector.registration.api.model.Participant;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.registration.api.TestUtils.createParticipant;
+
+class InMemoryParticipantStoreTest {
+
+    InMemoryParticipantStore store = new InMemoryParticipantStore();
+    Participant participant1 = createParticipant().build();
+    Participant participant1OtherEntry = createParticipant().name(participant1.getName()).build();
+    Participant participant2 = createParticipant().build();
+
+    @Test
+    void addAndListParticipants() {
+        assertThat(store.listParticipants()).isEmpty();
+
+        store.addParticipant(participant1);
+        assertThat(store.listParticipants()).containsOnly(participant1);
+    }
+
+    @Test
+    void addAndListParticipants_removesDuplicates() {
+        store.addParticipant(participant1);
+        store.addParticipant(participant1OtherEntry);
+        assertThat(store.listParticipants()).containsOnly(participant1OtherEntry);
+    }
+
+    @Test
+    void addAndListParticipants_twoEntries() {
+        store.addParticipant(participant1);
+        store.addParticipant(participant2);
+        assertThat(store.listParticipants()).containsOnly(participant1, participant2);
+    }
+}

--- a/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/api/RegistrationServiceTest.java
+++ b/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/api/RegistrationServiceTest.java
@@ -3,40 +3,37 @@ package org.eclipse.dataspaceconnector.registration.api;
 import org.eclipse.dataspaceconnector.registration.api.model.Participant;
 import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspaceconnector.registration.api.TestUtils.createParticipant;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RegistrationServiceTest {
 
-    TypeManager typeManager = new TypeManager();
     Monitor monitor = new ConsoleMonitor();
+    InMemoryParticipantStore participantStore = mock(InMemoryParticipantStore.class);
+    RegistrationService service = new RegistrationService(monitor, participantStore);
+    Participant participant = createParticipant().build();
 
     @Test
-    void listParticipants_empty() throws Exception {
-        var service = setUpRegistrationService("fakeprefix");
+    void listParticipants_empty() {
         assertThat(service.listParticipants()).isEmpty();
     }
 
     @Test
-    void listParticipants_fromFiles() throws Exception {
-        var service = setUpRegistrationService("test-");
-        assertThat(service.listParticipants()).hasSize(3);
-        assertThat(service.listParticipants()).extracting(Participant::getName).containsExactlyInAnyOrder("participant1", "participant2", "participant3");
-        assertThat(service.listParticipants()).extracting(Participant::getUrl).containsExactlyInAnyOrder("http://localhost:8282", "http://localhost:8283", "http://localhost:8284");
-        assertThat(service.listParticipants()).extracting(Participant::getSupportedProtocols).containsOnly(List.of("ids-multipart"));
+    void listParticipants() {
+        when(participantStore.listParticipants()).thenReturn(List.of(participant));
+        assertThat(service.listParticipants()).containsExactly(participant);
     }
 
-    @NotNull
-    private RegistrationService setUpRegistrationService(String nodeJsonPrefix) throws Exception {
-        var sampleFile = getClass().getClassLoader().getResource("test-participant1.json");
-        assertThat(sampleFile).isNotNull();
-        var nodeJsonDir = Path.of(sampleFile.toURI()).getParent();
-        return new RegistrationService(nodeJsonDir, nodeJsonPrefix, typeManager, monitor);
+    @Test
+    void addParticipant() {
+        service.addParticipant(participant);
+        verify(participantStore).addParticipant(participant);
     }
 }

--- a/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/api/TestUtils.java
+++ b/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/api/TestUtils.java
@@ -1,0 +1,19 @@
+package org.eclipse.dataspaceconnector.registration.api;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.registration.api.model.Participant;
+
+public class TestUtils {
+    private TestUtils() {
+    }
+
+    static final Faker FAKER = new Faker();
+
+    public static Participant.Builder createParticipant() {
+        return Participant.Builder.newInstance()
+                .name(FAKER.lorem().characters())
+                .url(FAKER.internet().url())
+                .supportedProtocol(FAKER.lorem().word())
+                .supportedProtocol(FAKER.lorem().word());
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ awaitility=4.1.1
 rsApi=3.0.0
 swagger=2.1.13
 jacksonVersion=2.13.1
+faker=1.0.2

--- a/resources/openapi/yaml/registration-service.yaml
+++ b/resources/openapi/yaml/registration-service.yaml
@@ -3,6 +3,20 @@ info:
   title: Eclipse Dataspace Connector Registration Service
   version: 0.0.1
 paths:
+  /registry/participant:
+    post:
+      tags:
+      - Registry
+      description: Asynchronously request to add a dataspace participant.
+      operationId: addParticipant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Participant'
+      responses:
+        "204":
+          description: No content
   /registry/participants:
     get:
       tags:

--- a/system-tests/build.gradle.kts
+++ b/system-tests/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 val awaitility: String by project
 val jupiterVersion: String by project
 val assertj: String by project
+val faker: String by project
 
 dependencies {
     testImplementation(project(":rest-client"))
@@ -26,4 +27,5 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
     testImplementation("org.awaitility:awaitility:${awaitility}")
+    testImplementation("com.github.javafaker:javafaker:${faker}")
 }

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/IntegrationTestUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/IntegrationTestUtils.java
@@ -1,0 +1,19 @@
+package org.eclipse.dataspaceconnector.registration.client;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.registration.client.models.Participant;
+
+class IntegrationTestUtils {
+    private IntegrationTestUtils() {
+    }
+
+    static final Faker FAKER = new Faker();
+
+    public static Participant createParticipant() {
+        return new Participant()
+                .name(FAKER.lorem().characters())
+                .url(FAKER.internet().url())
+                .addSupportedProtocolsItem(FAKER.lorem().word())
+                .addSupportedProtocolsItem(FAKER.lorem().word());
+    }
+}

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -4,26 +4,25 @@ import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.eclipse.dataspaceconnector.registration.client.models.Participant;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import static org.eclipse.dataspaceconnector.registration.client.IntegrationTestUtils.createParticipant;
 
 @IntegrationTest
 public class RegistrationApiClientTest {
-
     static final String API_URL = "http://localhost:8181/api";
 
     ApiClient apiClient = ApiClientFactory.createApiClient(API_URL);
     RegistryApi api = new RegistryApi(apiClient);
+    Participant participant = createParticipant();
 
     @Test
     void listParticipants() {
-        await().atMost(Duration.ofSeconds(30))
-                .untilAsserted(() ->
-                        assertThat(api.listParticipants())
-                        .extracting(Participant::getName)
-                        .containsExactlyInAnyOrder("consumer-eu", "consumer-us", "provider"));
+        assertThat(api.listParticipants())
+                .doesNotContain(participant);
 
+        api.addParticipant(participant);
+
+        assertThat(api.listParticipants())
+                .contains(participant);
     }
 }


### PR DESCRIPTION
Added a POST endpoint for participant enrolling.

Changed the backing store from file-based to in-memory.

In this implementation, enrollment is an immediate operation. In later PRs it will be an async process.

Relates to https://github.com/agera-edc/MinimumViableDataspace/issues/186
